### PR TITLE
Don't strip '+' from item names for variations

### DIFF
--- a/src/main/java/net/runelite/cache/codeupdater/apifiles/ItemVariationsUpdate.java
+++ b/src/main/java/net/runelite/cache/codeupdater/apifiles/ItemVariationsUpdate.java
@@ -47,7 +47,7 @@ public class ItemVariationsUpdate
 	private static String[][] replacements = new String[][]{
 		{"null", ""},
 		{"\\([^)]+\\)", ""},
-		{"[^a-zA-Z0-9 ]", ""},
+		{"[^a-zA-Z0-9 +]", ""},
 		{" [0-9]+|[0-9]+ ", ""},
 		{"uncharged | uncharged", ""},
 		{"new | new", ""},


### PR DESCRIPTION
This addresses https://github.com/runelite/runelite/discussions/16193, which reported that "Anti-venom" and "Anti-venom+" potions were considered variants of the same item, as well as "Antidote+" and "Antidote++" having the same issue. The only instances of the plus symbol I found in item names were:

1. Poisoned weapons ("Dragon dagger (p+)", "Bronze arrow (p++)", etc.)
2. "Weapon poison (+)" and "Weapon poison (++)"
3. The abovementioned anti-poison and anti-venom potions
4. Two abbreviated gnome foods ("Premade c+t batta", "Cheese+tom batta")

Of those, all of (1) and (2) are condensed into variants by having all text within parentheses removed, and (4) are not made into variants because they have no other items with names that match them, so the end result of this commit yields separate variation groups for anti-poison/venom potions using the "+" symbol.